### PR TITLE
是否可以如此来精简代码？

### DIFF
--- a/src/gopcp.v2/chapter6/webcrawler/module/sn.go
+++ b/src/gopcp.v2/chapter6/webcrawler/module/sn.go
@@ -56,9 +56,7 @@ func (gen *mySNGenertor) Max() uint64 {
 }
 
 func (gen *mySNGenertor) Next() uint64 {
-	gen.lock.RLock()
-	defer gen.lock.RUnlock()
-	return gen.next
+	return atomic.LoadUint64(&gen.next)
 }
 
 func (gen *mySNGenertor) CycleCount() uint64 {


### PR DESCRIPTION
Rlock+RUnlock是不是可以用 atomic.LoadUint64(&gen.next) 来直接代替？