### PR TITLE
possible missing 'continue'

### DIFF
--- a/src/gopcp.v2/chapter3/socket/tcp_socket.go
+++ b/src/gopcp.v2/chapter3/socket/tcp_socket.go
@@ -98,6 +98,7 @@ func serverGo() {
 		conn, err := listener.Accept() // 阻塞直至新连接到来。
 		if err != nil {
 			printServerLog("Accept Error: %s", err)
+			continue
 		}
 		printServerLog("Established a connection with a client application. (remote address: %s)",
 			conn.RemoteAddr())


### PR DESCRIPTION
possible missing 'continue' when error occurred in `Accept()`
在`Accept()` 发生错误的时候，少了一个continue