### PR TITLE
delete minor unreachable code caused by t.Fatal

### DIFF
--- a/src/gopcp.v2/chapter4/loadgen/gen_test.go
+++ b/src/gopcp.v2/chapter4/loadgen/gen_test.go
@@ -21,7 +21,6 @@ func TestStart(t *testing.T) {
 	err := server.Listen(serverAddr)
 	if err != nil {
 		t.Fatalf("TCP Server startup failing! (addr=%s)!\n", serverAddr)
-		t.FailNow()
 	}
 
 	// 初始化载荷发生器。
@@ -38,7 +37,6 @@ func TestStart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load generator initialization failing: %s\n",
 			err)
-		t.FailNow()
 	}
 
 	// 开始！
@@ -80,7 +78,6 @@ func TestStop(t *testing.T) {
 	err := server.Listen(serverAddr)
 	if err != nil {
 		t.Fatalf("TCP Server startup failing! (addr=%s)!\n", serverAddr)
-		t.FailNow()
 	}
 
 	// 初始化载荷发生器。
@@ -97,7 +94,6 @@ func TestStop(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load generator initialization failing: %s.\n",
 			err)
-		t.FailNow()
 	}
 
 	// 开始！


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>

see https://go.dev/play/p/w4Xuilq-KvA for example:
```go
package main

import (
	"testing"
)

func TestLastIndex(t *testing.T) {
	t.Fatalf("this line will print and exit")
	t.Errorf("this line can't print")
}

/* output:
=== RUN   TestLastIndex
    prog.go:8: this line will print and exit
--- FAIL: TestLastIndex (0.00s)
FAIL

Program exited.
*/

```